### PR TITLE
Bump supported gnome shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
     "shell-version" : [
         "40",
         "41",
-        "42"
+        "42",
+	"43"
     ],
     "url" : "https://github.com/dz4k/gnome-static-background",
     "uuid" : "static-background@denizaksimsek.com",


### PR DESCRIPTION
I've tested the extension and it seems to work well on gnome shell 43.
So this PR adds gnome shell 43 to metadata.json.

Thank you for creating this as it's a big upgrade from the way stock gnome handles overview background and i don't really like or need vertical overview.