### PR TITLE
Update to Gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
         "40",
         "41",
         "42",
-	"43"
+        "43",
+        "44"
     ],
     "url" : "https://github.com/dz4k/gnome-static-background",
     "uuid" : "static-background@denizaksimsek.com",


### PR DESCRIPTION
Makes the extension run on newer version of Gnome. Just basic support, might need some additional work to make app icons transparent...